### PR TITLE
fix: Add visual separation between current option and selectable options

### DIFF
--- a/src/entrypoints/rcfy.content/components/interactable/CustomSelect.svelte
+++ b/src/entrypoints/rcfy.content/components/interactable/CustomSelect.svelte
@@ -113,7 +113,7 @@
 	}
 
 	.options {
-		@apply bg-select absolute top-full z-10 border-interactable border-solid box-content border-t-0 flex flex-col rounded-b-small max-h-[40vh] overflow-auto;
+		@apply bg-select absolute top-full z-10 border-interactable border-solid box-content border-t-2 flex flex-col rounded-b-small max-h-[40vh] overflow-auto;
 
 		button {
 			@apply bg-option p-[5px] border-t-0 flex-shrink-0 last:border-b-0 hover:bg-hover;


### PR DESCRIPTION
This is one option of fixing #9, but there's probably better ways too. I've added a small border between the current option and the selectable options.
![image](https://github.com/Xyl-AU/Reddit-Comments-for-YouTube/assets/23165606/5d011670-c994-4584-bb46-a2fc515b7c6c)
