### PR TITLE
Fix time for Lemmy comments

### DIFF
--- a/src/lib/tools/TimeTools.ts
+++ b/src/lib/tools/TimeTools.ts
@@ -93,6 +93,5 @@ export function timestampToRelativeTime(timestamp: number) {
 }
 
 export function lemmyTimestampToEpoch(timestamp: string) {
-	const utcTime = `${timestamp}+00:00`;
-	return ~~(Date.parse(utcTime) / 1000);
+	return Math.floor(Date.parse(timestamp) / 1000);
 }


### PR DESCRIPTION
Hi, most Lemmy instances I've seen end the timestamp with a `Z` for UTC, adding another `+00:00` tends to invalidate the date, causing it go to NaN and say "54 years ago" on the comment. This tiny PR fixes that.

Let my know if there are instances with a badly formatted date and I can add a check for them though.

Thanks,
Steve